### PR TITLE
Handle rows with no value as empty strings

### DIFF
--- a/src/sheets.ts
+++ b/src/sheets.ts
@@ -63,7 +63,7 @@ export function remapSheetValues(opts: GetCopyOptions, sheet: SpreadsheetValuesS
   // Return all the non-empty rows, reduced to a pair of key/value
   return rows
     .map(row => [row[keyIndex], row[valueIndex]] as RowTuple)
-    .filter(row => !!row[0] && !!row[1]);
+    .filter(row => !!row[0]);
 }
 
 export function sortObjectKeys<T>(obj: T): T {
@@ -93,7 +93,7 @@ export function buildLocaleTree(entries: Array<RowTuple>) {
 
       keyparts.forEach((part, idx) => {
         if (idx === (keyparts.length - 1)) {
-          subkey[part] = value;
+          subkey[part] = value || "";
         } else if (subkey[part] === undefined) {
           subkey = subkey[part] = {} as LocaleTree;
         } else {
@@ -101,7 +101,7 @@ export function buildLocaleTree(entries: Array<RowTuple>) {
         }
       });
     } else {
-      tree[key] = value;
+      tree[key] = value || "";
     }
   });
 

--- a/test/sheets.test.js
+++ b/test/sheets.test.js
@@ -55,6 +55,12 @@ describe("buildLocaleTree", function() {
     assert.deepEqual(result, { foo: { bar: { baz: "qux" }, asdf: "qwerty" }}, "Converted tuples to object");
   });
 
+  it("should handle key and sub-object keys with empty values", function() {
+    const result = buildLocaleTree([ ["foo.bar.baz", undefined], ["asdf", undefined] ]);
+
+    assert.deepEqual(result, { foo: { bar: { baz: "" }}, asdf: "" }, "Converted tuples to object");
+  });
+
   it("should return sorted keys", function() {
     const result = buildLocaleTree([ ["foo", "bar"], ["asdf", "qwerty"] ]);
     const expected = { asdf: "qwerty", foo: "bar" };


### PR DESCRIPTION
Sometimes we want a key to map to an empty string. In the spreadsheet, and empty cell will get turned into `undefined` when pulled in to JS, and then `undefined` values will get dropped when serializing to JSON, so we want to convert them to empty strings.