### PR TITLE
Add a GHA workflow to tag and publish to GPR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 Ayogo Health Inc.
+
 name: CI
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+# Copyright 2023 Ayogo Health Inc.
+
+name: Publish Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version-type:
+        description: Type of version update to tag
+        required: true
+        type: choice
+        default: patch
+        options:
+          - major
+          - minor
+          - patch
+          - Custom
+      version-str:
+        description: Custom version string (if tagging custom)
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@ayogohealth'
+
+      - name: npm test
+        run: npm cit
+
+      - name: npm version
+        run: |
+            npm version ${{ github.event.inputs.version-type == 'Custom' && github.event.inputs.version-str || github.event.inputs.version-type }}
+
+      - name: git push
+        run: |
+            git push origin --follow-tags
+
+      - name: npm publish
+        run: |
+            npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In theory, this should make it almost effortless to tag and publish new version to GitHub Package Registry